### PR TITLE
Add missing appsettings for microservices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ project.fragment.lock.json
 artifacts/
 .vs/
 appsettings.json
+!ApiGateway/appsettings.json
+!IdentityService/appsettings.json
+!ContentService/appsettings.json
+!TransactionCore/appsettings.json
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt
 

--- a/ContentService/appsettings.json
+++ b/ContentService/appsettings.json
@@ -1,0 +1,29 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "BaseUrl": "https://localhost:44369",
+  "JwtSettings": {
+    "SecretKey": "YourVeryLongSecretKeyThatIsAtLeast32Bytes!"
+  },
+  "IdentitySettings": {
+    "Authority": "https://localhost:44350",
+    "Audience": "content-service",
+    "Issuer": "IdentityService"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=34.13.154.160;Initial Catalog=ContentService;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
+  },
+  "GCS": {
+    "BucketName": "arbito-content-images"
+  },
+  "RabbitMQ": {
+    "Host": "rabbitmq://localhost",
+    "Username": "guest",
+    "Password": "guest"
+  },
+  "AllowedHosts": "*"
+}

--- a/TransactionCore/appsettings.json
+++ b/TransactionCore/appsettings.json
@@ -1,0 +1,32 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "BaseUrl": "https://localhost:44351",
+  "JwtSettings": {
+    "SecretKey": "YourVeryLongSecretKeyThatIsAtLeast32Bytes!"
+  },
+  "IdentitySettings": {
+    "Authority": "https://localhost:44350",
+    "Audience": "transaction-service",
+    "Issuer": "IdentityService"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=34.13.154.160;Initial Catalog=TransactionCore;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
+  },
+  "GCS": {
+    "BucketName": "arbito-transaction-images"
+  },
+  "Services": {
+    "IdentityServiceUrl": "https://localhost:44350"
+  },
+  "RabbitMQ": {
+    "Host": "rabbitmq://localhost",
+    "Username": "guest",
+    "Password": "guest"
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- commit appsettings.json for ContentService with proper URLs, security, and messaging configuration
- add appsettings.json for TransactionCore including identity and RabbitMQ settings
- update .gitignore to track these configuration files

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b949f2f8832bbc188901a098acc5