### PR TITLE
Update SQL Server port to 1434 in configuration

### DIFF
--- a/ContentService/appsettings.json
+++ b/ContentService/appsettings.json
@@ -15,7 +15,7 @@
     "Issuer": "IdentityService"
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=34.13.154.160;Initial Catalog=ContentService;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=localhost,1434;Initial Catalog=ContentService;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
   },
   "GCS": {
     "BucketName": "arbito-content-images"

--- a/IdentityService/appsettings.json
+++ b/IdentityService/appsettings.json
@@ -17,7 +17,7 @@
     ]
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=34.13.154.160;Initial Catalog=IdentityService;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=localhost,1434;Initial Catalog=IdentityService;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
   },
   "GCS": {
     "BucketName": "arbito-identity-images"

--- a/TransactionCore/appsettings.json
+++ b/TransactionCore/appsettings.json
@@ -15,7 +15,7 @@
     "Issuer": "IdentityService"
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=34.13.154.160;Initial Catalog=TransactionCore;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=localhost,1434;Initial Catalog=TransactionCore;Persist Security Info=True;User ID=usr_arbito;Password=Arbito.12345;Encrypt=True;TrustServerCertificate=True"
   },
   "GCS": {
     "BucketName": "arbito-transaction-images"


### PR DESCRIPTION
## Summary
- use port 1434 for SQL Server in Identity, Content, and Transaction services

## Testing
- `docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Your_password123" -p 1434:1433 -d mcr.microsoft.com/mssql/server:2022-latest` *(fails: command not found: docker)*
- `dotnet build` *(fails: command not found: dotnet)*
- `dotnet run --project IdentityService` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b2be3608f0832b86644b281ca4891e