### PR TITLE
Add optional UseDatabase flag to TransactionCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Arbito
+
+## TransactionCore configuration
+
+TransactionCore includes a `UseDatabase` flag (default `true`).
+Set `UseDatabase=false` in `appsettings.json` or via environment variable to
+run the service without a database. For example:
+
+```bash
+UseDatabase=false dotnet run --project TransactionCore
+```
+
+When disabled, the service uses an in-memory database and skips migrations and
+database-dependent background services.
+

--- a/TransactionCore/TransactionCore.csproj
+++ b/TransactionCore/TransactionCore.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.0.0" />

--- a/TransactionCore/appsettings.json
+++ b/TransactionCore/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "UseDatabase": true,
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- make database usage conditional via new `UseDatabase` flag
- skip SQL Server setup, background jobs and migrations when disabled
- document how to run TransactionCore without a database

## Testing
- `dotnet test` *(fails: dotnet command not found; unable to install SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c0c560e8832b9a92500bd65b4dfd